### PR TITLE
fix: incorrect transparency on some gif/pcx files

### DIFF
--- a/KCTools/Program.cs
+++ b/KCTools/Program.cs
@@ -439,12 +439,8 @@ public class RootCommand
                     case ".gif":
                     {
                         magickImage = new MagickImage(stream);
-                        var colorZero = magickImage.GetColormapColor(0);
-                        if (colorZero != null)
-                        {
-                            magickImage.Transparent(colorZero);
-                        }
-
+                        magickImage.Alpha(AlphaOption.Set);
+                        magickImage.SetColormapColor(0, MagickColors.Transparent);
                         break;
                     }
                     case ".tga":


### PR DESCRIPTION
Copied from KCModelEditor. Should probably think about splitting image handling into a shared project.