### PR TITLE
fix: anim light bitmask corruption

### DIFF
--- a/KeepersCompound.Lighting/LightMapper.cs
+++ b/KeepersCompound.Lighting/LightMapper.cs
@@ -794,7 +794,12 @@ public class LightMapper
                                         cell.AnimLights.Add((ushort)light.LightTableIndex);
                                     }
 
-                                    info.AnimLightBitmask |= 1u << paletteIdx;
+                                    // If it's over 32 then the shift ends up corrupting the bitmask
+                                    if (paletteIdx < 32)
+                                    {
+                                        info.AnimLightBitmask |= 1u << paletteIdx;
+                                    }
+
                                     layer = paletteIdx + 1;
                                 }
 


### PR DESCRIPTION
Closes #113 

Caused a mismatch between what would be written to file, and what would be read from the file. DromEd and KCTools would then crash when trying to read what was written.