### PR TITLE
fix: order-dependant variable value when config variable is a prefix of other variables

### DIFF
--- a/KeepersCompound.Dark/InstallContext.cs
+++ b/KeepersCompound.Dark/InstallContext.cs
@@ -175,7 +175,7 @@ public class InstallContext
 
         foreach (var line in lines)
         {
-            if (line.StartsWith(varName))
+            if (line.StartsWith($"{varName} "))
             {
                 value = line[(line.IndexOf(' ') + 1)..];
                 return true;


### PR DESCRIPTION
Closes #138 