### PR TITLE
feat: log lighting stage exceptions

### DIFF
--- a/KCTools/Program.cs
+++ b/KCTools/Program.cs
@@ -137,7 +137,18 @@ public class RootCommand
                 }
                 else
                 {
-                    lightMapper.Light(resources, hierarchy, worldRep, brList, rendParams, lmParams);
+                    try
+                    {
+                        lightMapper.Light(resources, hierarchy, worldRep, brList, rendParams, lmParams);
+                    }
+                    catch (Exception e)
+                    {
+                        foreach (var line in e.ToString().Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+                        {
+                            Log.Error("{l}", line);
+                        }
+                        return ExitCode.Error;
+                    }
                     if (resources.TryGetDbFileVirtualPath(MissionName, out var virtualMisPath) &&
                         resources.TryGetFilePath(virtualMisPath, out var misPath))
                     {


### PR DESCRIPTION
Ideally there shouldn't be any exceptions bubbling up, but if a crash does occur logging it does at least make it easier to debug without users having to send me their problematic maps.