### PR TITLE
fix: incorrect gif transparency

### DIFF
--- a/KeepersCompound.Formats.Images/DarkImageLoader.cs
+++ b/KeepersCompound.Formats.Images/DarkImageLoader.cs
@@ -88,14 +88,21 @@ public static class DarkImageLoader
     private static Image LoadGif(Stream stream)
     {
         var image = Image.Load(stream);
-        var meta = image.Metadata.GetGifMetadata();
-        meta.BackgroundColorIndex = 0;
-
         for (var i = image.Frames.Count - 1; i > 0; i--)
         {
             image.Frames.RemoveFrame(i);
         }
 
+        var frameMetadata = image.Frames[0].Metadata.GetGifMetadata();
+        frameMetadata.HasTransparency = true;
+        frameMetadata.TransparencyIndex = 0;
+        image.Metadata.GetGifMetadata().BackgroundColorIndex = 0;
+
+        // We have to re-encode again, otherwise the transparency metadata gets dropped when saving as PNG
+        using var newStream = new MemoryStream();
+        image.SaveAsGif(newStream);
+        newStream.Position = 0;
+        image = Image.Load(newStream);
         return image;
     }
 }


### PR DESCRIPTION
I thought this was working, but it turns out it never was... I was both not actually setting the per-frame transparency metadata, and the metadata I was setting was getting dropped.

Turns out you need to save the gif again in gif format to get the metadata encoded. Just saving straight away as png drops it. Supposedly imagesharp v4 added cross-format metadata conversions that might solve this, but upgrading to v4 requires applying for an explicit license key to be able to build so no thanks.